### PR TITLE
Update metadata to prepare for IETF solicitation

### DIFF
--- a/draft-tus-resumable-uploads-protocol.md
+++ b/draft-tus-resumable-uploads-protocol.md
@@ -1,12 +1,12 @@
 ---
 title: tus - Resumable Uploads Protocol
-abbrev: TODO - Abbreviation
+abbrev: Resumable Uploads
 docname: draft-tus-resumable-uploads-protocol-latest
-category: info
+category: std
 
 ipr: trust200902
-area: General
-workgroup: TODO Working Group
+area: ART
+workgroup: HTTP
 keyword: Internet-Draft
 
 stand_alone: yes


### PR DESCRIPTION
Update the document metadata assuming that we wish to target the HTTP
WG. 

This change also moves the intended status from informational to
standards track. This reflects my understanding of the author group's
intent with the protocol.
