### PR TITLE
Rephrase "resources allocated for" and "record of"

### DIFF
--- a/draft-tus-resumable-uploads-protocol.md
+++ b/draft-tus-resumable-uploads-protocol.md
@@ -191,7 +191,7 @@ If the end of the request body is not the end of the upload, the `Upload-Incompl
 
 The client MAY send the metadata of the file using headers such as `Content-Type` (see {{Section 8.3 of HTTP}} and `Content-Disposition` {{!RFC6266}} when starting a new upload. It is OPTIONAL for the client to repeat the metadata when resuming an upload.
 
-If the server has no record of the token but the offset is non-zero, it MUST respond with 404 (Not Found) status code.
+If the server does not consider the upload associated with the token in the `Upload-Token` header field active, but the resumption offset is non-zero, it MUST respond with 404 (Not Found) status code.
 
 The server MAY terminate any ongoing Upload Transfer Procedure ({{upload-transfer}}) for the same token. Since the client is not allowed to perform multiple transfers in parallel, the server can assume that the previous attempt has already failed. Therefore, the server MAY abruptly terminate the previous HTTP connection or stream.
 
@@ -248,13 +248,13 @@ The request MUST use the `HEAD` method and include the `Upload-Token` header. Th
 
 The client MUST NOT perform the Offset Retrieving Procedure ({{offset-retrieving}}) while the Upload Transfer Procedures ({{upload-transfer}}) is in progress.
 
-If the server has resources allocated for this token, it MUST send back a `204 (No Content)` response with a header `Upload-Offset` which indicates the resumption offset for the client.
+If the server considers the upload associated with this token active, it MUST send back a `204 (No Content)` response with a header `Upload-Offset` which indicates the resumption offset for the client.
 
 The offset MUST be accepted by a subsequent Upload Transfer Procedure ({{upload-transfer}}). Due to network delay and reordering, the server might still be receiving data from an ongoing transfer for the same token, which in the client perspective has failed. The server MAY terminate any transfers for the same token before sending the response by abruptly terminating the HTTP connection or stream. Alternatively, the server MAY keep the ongoing transfer alive but ignore further bytes received past the offset.
 
 The response SHOULD include `Cache-Control: no-store` header to prevent HTTP caching.
 
-If the server has no record of this token, it MUST respond with `404 (Not Found)` status code.
+If the server does not consider the upload associated with this token active, it MUST respond with `404 (Not Found)` status code.
 
 The client MUST NOT start more than one Upload Transfer Procedures ({{upload-transfer}}) based on the resumption offset from a single Offset Retrieving Procedure ({{offset-retrieving}}).
 
@@ -278,11 +278,11 @@ If the client wants to terminate the transfer without the ability to resume, it 
 
 The request MUST use the `DELETE` method and include the `Upload-Token` header. The request MUST NOT include the `Upload-Offset` header or the `Upload-Incomplete` header. The server MUST reject the request with the `Upload-Offset` header or the `Upload-Incomplete` header by sending a `400 (Bad Request)` response.
 
-If the server has successfully released the resources allocated for this token, it MUST send back a `204 (No Content)` response.
+If the server has successfully deactivated this token, it MUST send back a `204 (No Content)` response.
 
 The server MAY terminate any ongoing Upload Transfer Procedure ({{upload-transfer}}) for the same token before sending the response by abruptly terminating the HTTP connection or stream.
 
-If the server has no record of the token in `Upload-Token`, it MUST respond with `404 (Not Found)` status code.
+If the server does not consider the upload associated with this token active, it MUST respond with `404 (Not Found)` status code.
 
 If the server does not support cancellation, it MUST respond with `405 (Method Not Allowed)` status code.
 


### PR DESCRIPTION
Resolves #21