### PR TITLE
Try to make it clearer what an upload is

### DIFF
--- a/draft-tus-resumable-uploads-protocol.md
+++ b/draft-tus-resumable-uploads-protocol.md
@@ -87,7 +87,7 @@ The Resumable Uploads Protocol consists of several procedures that rely on HTTP 
 A single upload is a sequence of one or more procedures. Each upload is uniquely
 identified by a token chosen by a client. The token is carried in the Upload-Token header field; see {{upload-token}}.
 
-The remainder of this section uses an examples of a file upload to illustrate permutations of procedure sequence. Note, however, that HTTP message exchanges use representation data (see {{Section 8.1 of HTTP}}), which means that procedures can apply to many forms of content.
+The remainder of this section uses examples of a file upload to illustrate permutations of procedure sequence. Note, however, that HTTP message exchanges use representation data (see {{Section 8.1 of HTTP}}), which means that procedures can apply to many forms of content.
 
 ## Example 1: Complete upload of file with known size
 

--- a/draft-tus-resumable-uploads-protocol.md
+++ b/draft-tus-resumable-uploads-protocol.md
@@ -158,11 +158,11 @@ Client                                      Server
 ~~~
 {: #fig-upload-cancellation-procedure title="Upload Cancellation Procedure"}
 
-## Example 2: File of unknown size
+## Example 2: Upload as a series of parts
 
-In some cases a client does no know the final size of a resource before it initiates an upload. For instance, a file that is contains data from a stream source.
+In some cases clients might prefer to upload a file as a series of parts sent across multiple HTTP messages. One use case is to overcome server limits on HTTP message content size. Another use case is where the client does not know the final size, such as when file data originates from a streaming source.
 
-This example shows how a client can upload incomplete chunks of a file to the server across a sequence of procedures.
+This example shows how the client, with prior knowledge about the server's resumable upload support, can upload parts of a file over a sequence of procedures.
 
 1) If the client is aware that the server supports resumable upload, it can use the Upload Transfer Procedure with the `Upload-Incomplete` header to start an upload.
 
@@ -180,7 +180,7 @@ Client                                      Server
 ~~~
 {: #fig-upload-cancellation-procedure-usage title="Upload Transfer Procedure Usage"}
 
-2) The last chunk of the upload does not have the `Upload-Incomplete` header.
+2) The last part of the upload does not have the `Upload-Incomplete` header.
 
 ~~~
 Client                                      Server

--- a/draft-tus-resumable-uploads-protocol.md
+++ b/draft-tus-resumable-uploads-protocol.md
@@ -55,9 +55,9 @@ Clients often encounter interrupted data transfers as a result of canceled reque
 
 # Introduction
 
-Clients often encounter interrupted data transfers as a result of canceled requests or dropped connections. Prior to interruption, part of a representation (see {{Section 3.2 of HTTP}})may have been exchanged. To complete the data transfer of the entire representation, it is often desirable to issue subsequent requests that transfer only the remainder of the representation. HTTP range requests (see {{Section 14 of HTTP}}) support this concept of resumable downloads from server to client.
+Clients often encounter interrupted data transfers as a result of canceled requests or dropped connections. Prior to interruption, part of a representation (see {{Section 3.2 of HTTP}}) might have been exchanged. To complete the data transfer of the entire representation, it is often desirable to issue subsequent requests that transfer only the remainder of the representation. HTTP range requests (see {{Section 14 of HTTP}}) support this concept of resumable downloads from server to client.
 
-HTTP methods such as POST or PUT can be used by clients to request processing of representation data enclosed in the request message. The transfer of representation data from client to server is often referred to as an upload. Uploads are just as likely as downloads to suffer from the effects of data transfer interruption. Humans can play a role in upload interruptions through manual actions such pausing an upload. Regardless of the cause of an interruption, servers may have received part of the representation before its occurrence and it is desirable if clients can complete the data transfer by sending only the remainder of the representation. The process of sending additional parts of a representation using subsequent HTTP requests from client to server is herein referred to as a resumable upload.
+HTTP methods such as POST or PUT can be used by clients to request processing of representation data enclosed in the request message. The transfer of representation data from client to server is often referred to as an upload. Uploads are just as likely as downloads to suffer from the effects of data transfer interruption. Humans can play a role in upload interruptions through manual actions such as pausing an upload. Regardless of the cause of an interruption, servers may have received part of the representation before its occurrence and it is desirable if clients can complete the data transfer by sending only the remainder of the representation. The process of sending additional parts of a representation using subsequent HTTP requests from client to server is herein referred to as a resumable upload.
 
 Connection interruptions are common and the absence of a standard mechanism for resumable uploads has lead to a proliferation of custom solutions. Some of those use HTTP, while others rely on other transfer mechanisms entirely. An HTTP-based standard solution is desirable for such a common class of problem.
 
@@ -89,9 +89,9 @@ identified by a token chosen by a client. The token is carried in the Upload-Tok
 
 The remainder of this section uses an examples of a file upload to illustrate permutations of procedure sequence. Note, however, that HTTP message exchanges use representation data (see {{Section 8.1 of HTTP}}), which means that procedures can apply to many forms of content.
 
-## Example 1: File of known size
+## Example 1: Complete upload of file with known size
 
-In this example, the client attempts to upload an file where the final, experiences an interruption, and then attempts to resume the upload.
+In this example, the client first attempts to upload a file with a known size in a single HTTP request. An interruption occurs and the client then attempts to resume the upload using subsequent HTTP requests.
 
 1) The Upload Transfer Procedure ({{upload-transfer}}) can be used to notify the server that the client wants to begin an upload. The server should then reserve the required resources to accept the upload from the client. The client also begins transferring the entire file in the request body. The request includes the Upload-Token header, which is used for identifying future requests related to this upload. An informational response can be sent to the client to signal the support of resumable upload on the server.
 

--- a/draft-tus-resumable-uploads-protocol.md
+++ b/draft-tus-resumable-uploads-protocol.md
@@ -42,23 +42,26 @@ author:
 
 normative:
   RFC2119:
+  HTTP: I-D.ietf-httpbis-semantics
 
 informative:
 
 
 --- abstract
 
-This document describes a mechanism which allows HTTP endpoints to add support for resumable uploads. It aims to address the issues around clients having to upload content from the start in case the original upload fails.
+Clients often encounter interrupted data transfers as a result of canceled requests or dropped connections. Prior to interruption, part of a representation may have been exchanged. To complete the data transfer of the entire representation, it is often desirable to issue subsequent requests that transfer only the remainder of the representation. HTTP range requests support this concept of resumable downloads from server to client. This document describes a mechanism that supports resumable uploads from client to server.
 
 --- middle
 
 # Introduction
 
-HTTP {{!HTTP=I-D.ietf-httpbis-semantics}} already provides resumable downloads using the `Range` header. However, on its own HTTP does not contain a standardized mechanism for resumable uploads. This has lead to a situation where many web services implement a proprietary solution for handling connection issues during file uploads. Such a scattered landscape makes it impossible to develop clients with resumable upload capabilities in a generic approach without focusing on specific, proprietary solutions. It also limits the benefits of resumable uploads to web services that can free up the resources to implement this.
+Clients often encounter interrupted data transfers as a result of canceled requests or dropped connections. Prior to interruption, part of a representation (see {{Section 3.2 of HTTP}})may have been exchanged. To complete the data transfer of the entire representation, it is often desirable to issue subsequent requests that transfer only the remainder of the representation. HTTP range requests (see {{Section 14 of HTTP}}) support this concept of resumable downloads from server to client.
 
-Resuming a previously interrupted upload continues the data transfer where it left off, without the need to transfer the first part again. This capability is especially important in applications handling large files or operating in areas with unreliable network infrastructure. Upload interruptions can occur voluntarily, i.e. the end-user wants to pause the upload, or involuntarily, i.e. the network connection drops.
+HTTP methods such as POST or PUT can be used by clients to request processing of representation data enclosed in the request message. The transfer of representation data from client to server is often referred to as an upload. Uploads are just as likely as downloads to suffer from the effects of data transfer interruption. Humans can play a role in upload interruptions through manual actions such pausing an upload. Regardless of the cause of an interruption, servers may have received part of the representation before its occurrence and it is desirable if clients can complete the data transfer by sending only the remainder of the representation. The process of sending additional parts of a representation using subsequent HTTP requests from client to server is herein referred to as a resumable upload.
 
-This protocol specifies an approach for clients and servers to implement resumable uploads on top of HTTP/1.1, HTTP/2 and HTTP/3, allowing the reuse of existing infrastructure. It also allows clients to upgrade regular uploads automatically to resumable uploads.
+Connection interruptions are common and the absence of a standard mechanism for resumable uploads has lead to a proliferation of custom solutions. Some of those use HTTP, while others rely on other transfer mechanisms entirely. An HTTP-based standard solution is desirable for such a common class of problem.
+
+This document defines the Resumable Uploads Protocol, an optional mechanism for resumable uploads using HTTP that is backwards-compatible with conventional HTTP uploads. When an upload is interrupted, clients can send subsequent requests to query the server state and use this information to the send remaining data. Alternatively, they can cancel the upload entirely.
 
 # Conventions and Definitions
 
@@ -69,9 +72,26 @@ The terms byte sequence, Item, string, sf-binary, sf-boolean, sf-integer, sf-str
 
 The terms client and server are imported from {{HTTP}}.
 
+Upload: A sequence of one or more procedures, uniquely identified by a token chosen by a client.
+
+Procedure: An HTTP message exchange for that can be used for resumable uploads.
+
 # Uploading Overview
 
-The uploading of a file using the Resumable Uploads Protocol consists of multiple procedures:
+The Resumable Uploads Protocol consists of several procedures that rely on HTTP message exchanges. The following procedures are defined:
+
+* Upload Transfer Procedure ({{upload-transfer}})
+* Offset Retrieving Procedure ({{offset-retrieving}})
+* Upload Cancellation Procedure ({{upload-cancellation}})
+
+A single upload is a sequence of one or more procedures. Each upload is uniquely
+identified by a token chosen by a client. The token is carried in the Upload-Token header field; see {{upload-token}}.
+
+The remainder of this section uses an examples of a file upload to illustrate permutations of procedure sequence. Note, however, that HTTP message exchanges use representation data (see {{Section 8.1 of HTTP}}), which means that procedures can apply to many forms of content.
+
+## Example 1: File of known size
+
+In this example, the client attempts to upload an file where the final, experiences an interruption, and then attempts to resume the upload.
 
 1) The Upload Transfer Procedure ({{upload-transfer}}) can be used to notify the server that the client wants to begin an upload. The server should then reserve the required resources to accept the upload from the client. The client also begins transferring the entire file in the request body. The request includes the Upload-Token header, which is used for identifying future requests related to this upload. An informational response can be sent to the client to signal the support of resumable upload on the server.
 
@@ -138,7 +158,11 @@ Client                                      Server
 ~~~
 {: #fig-upload-cancellation-procedure title="Upload Cancellation Procedure"}
 
-In the above example, the client attempted to upload the entire file in a single request, indicated by omitting the `Upload-Incomplete` header. For advanced use cases, the client is allowed to upload incomplete chunks of a file to the server sequentially. One example is the uploading of a streaming data source which is not yet completely read yet:
+## Example 2: File of unknown size
+
+In some cases a client does no know the final size of a resource before it initiates an upload. For instance, a file that is contains data from a stream source.
+
+This example shows how a client can upload incomplete chunks of a file to the server across a sequence of procedures.
 
 1) If the client is aware that the server supports resumable upload, it can use the Upload Transfer Procedure with the `Upload-Incomplete` header to start an upload.
 
@@ -169,8 +193,6 @@ Client                                      Server
 |                                                |
 ~~~
 {: #fig-upload-cancellation-procedure-last-chunk title="Upload Transfer Procedure Last Chunk"}
-
-This overview section talked about uploading files, as this is a common use case. However, this protocol also support uploading of streaming data sources, such as live video streams. Therefore, this document extends its terminology to include all data sources and instead refers to _uploads_ instead of _files_.
 
 # Upload Transfer Procedure {#upload-transfer}
 


### PR DESCRIPTION
The main intent of this PR is to make it clearer what an upload is, based on my perspective of the spec

This ended up a little larger than I first planned, sorry. It might also be opposed to what others think the useful definition of upload is.

I tried to use HTTP terms like representation where I could. This should make it easier to contrast with Range requests that support resumable downloads.

I might not have gone far enough in applying the terminology everywhere. But I wanted to get some review before investing more time on a dead end.

PS. I'd missed that there were actually two examples of different uploads in the overview section. I think this is important not to miss, so I promoted them to their own sections with an up-front description of what the example is attempting to demonstrate.