### PR TITLE
fix: typo

### DIFF
--- a/draft-tus-httpbis-resumable-uploads-protocol.md
+++ b/draft-tus-httpbis-resumable-uploads-protocol.md
@@ -144,7 +144,7 @@ Client                                      Server
 ~~~
 {: #fig-resuming-upload title="Resuming Upload"}
 
-4) If the client is not interesting in completing the upload anymore, it can instruct the server to delete the upload and free all related resources using the Upload Cancellation Procedure ({{upload-cancellation}}).
+4) If the client is not interested in completing the upload anymore, it can instruct the server to delete the upload and free all related resources using the Upload Cancellation Procedure ({{upload-cancellation}}).
 
 ~~~
 Client                                      Server


### PR DESCRIPTION
Hi,

This PR fixes a typo in the `3.1.  Example 1: Complete upload of file with known size` section.

Cheers.