### PR TITLE
Prepare for adoption and migration to http-extensions repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 This is the working area for the IETF [RESUMABLE Working Group](https://datatracker.ietf.org/wg/resumable/documents/) Internet-Draft, "tus - Resumable Uploads Protocol".
 
-* [Editor's Copy](https://tus.github.io/tus-v2/#go.draft-tus-httpbis-resumable-uploads-protocol.html)
-* [Working Group Draft](https://tools.ietf.org/html/draft-tus-httpbis-resumable-uploads-protocol)
-* [Compare Editor's Copy to Working Group Draft](https://tus.github.io/tus-v2/#go.draft-tus-httpbis-resumable-uploads-protocol.diff)
+* [Editor's Copy](https://tus.github.io/tus-v2/#go.draft-ietf-httpbis-resumable-upload.html)
+* [Working Group Draft](https://tools.ietf.org/html/draft-ietf-httpbis-resumable-upload)
+* [Compare Editor's Copy to Working Group Draft](https://tus.github.io/tus-v2/#go.draft-ietf-httpbis-resumable-upload.diff)
 
 ## Existing Implementations
 
 This draft is still a work-in-progress. However, some experimental implementation already exist:
 
-- [tusd server](https://github.com/tus/tusd/pull/568) 
+- [tusd server](https://github.com/tus/tusd/pull/568)
 - [tusdotnet server](https://github.com/tusdotnet/tusdotnet/tree/POC/tus2)
 - Example server in [`examples/`](/examples)
 

--- a/draft-ietf-httpbis-resumable-upload.md
+++ b/draft-ietf-httpbis-resumable-upload.md
@@ -1,7 +1,7 @@
 ---
 title: tus - Resumable Uploads Protocol
 abbrev: Resumable Uploads
-docname: draft-tus-httpbis-resumable-uploads-protocol-latest
+docname: draft-ietf-httpbis-resumable-upload-latest
 category: std
 
 ipr: trust200902
@@ -13,32 +13,35 @@ stand_alone: yes
 smart_quotes: no
 pi: [toc, sortrefs, symrefs]
 
+venue:
+  group: HTTP
+  type: Working Group
+  home: https://httpwg.org/
+  mail: ietf-http-wg@w3.org
+  arch: https://lists.w3.org/Archives/Public/ietf-http-wg/
+  repo: https://github.com/httpwg/http-extensions/labels/resumable-upload
+github-issue-label: resumable-upload
+
 author:
   -
     ins: M. Kleidl
     name: Marius Kleidl
+    role: editor
     organization: Transloadit Ltd
     email: marius@transloadit.com
   -
-    ins: J. Mehta
-    name: Jiten Mehta
-    organization: Apple Inc.
-    email: jmehta@apple.com
-  -
     ins: G. Zhang
     name: Guoye Zhang
+    role: editor
     organization: Apple Inc.
     email: guoye_zhang@apple.com
   -
     ins: L. Pardue
     name: Lucas Pardue
+    role: editor
     organization: Cloudflare
     email: lucaspardue.24.7@gmail.com
-  -
-    ins: S. Matsson
-    name: Stefan Matsson
-    organization: JellyHive
-    email: s.matsson@gmail.com
+
 
 normative:
   RFC2119:
@@ -470,7 +473,9 @@ Specification: This document
 # Acknowledgments
 {:numbered="false"}
 
-TODO acknowledge.
+This document is based on an Internet-Draft specification written by Jiten Mehta, Stefan Matsson, and the authors of this document.
+
+TODO: more acknowledgements.
 
 # Appendix
 {:numbered="false"}


### PR DESCRIPTION
The I-D has been adopted by the HTTP WG. The chairs gave us instructions for migration to https://github.com/httpwg/http-extensions: nominate editors and rename the draft filename.

This change reflects into metadata the outcome of those decisions.

No content changes have occured. Those should be deferred until the migration has completed. Any future changes should be tracked at the http-extensions repo.